### PR TITLE
Update prism to 1.29.0 - Enable plugins toolbar/copy-to-clipboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 /npm-debug.log*
 /testem.log
 /yarn-error.log
+/.vscode/
 
 # ember-try
 /.node_modules.ember-try/

--- a/app/templates/libraries/prism/index.hbs
+++ b/app/templates/libraries/prism/index.hbs
@@ -16,6 +16,7 @@
 			prism: {
 				theme: 'okidai',
 				languages: ['sql', 'json', 'javascript'],
+				copyToClipboard: true,
 			}
 		});
 		return app.toTree();

--- a/packages/prism.js/index.js
+++ b/packages/prism.js/index.js
@@ -1,33 +1,41 @@
 'use strict';
 
 module.exports = {
-
 	name: require('./package').name,
 
 	included(app) {
-
 		this._super.included.apply(this, ...arguments);
 
 		this.opts = app.options.prism || {};
 
 		app.import(`node_modules/prismjs/prism.js`);
 
+		if (this.opts.copyToClipboard) {
+			app.import('node_modules/prismjs/plugins/toolbar/prism-toolbar.js');
+			app.import(
+				'node_modules/prismjs/plugins/toolbar/prism-toolbar.css'
+			);
+			app.import(
+				'node_modules/prismjs/plugins/copy-to-clipboard/prism-copy-to-clipboard.js'
+			);
+		}
+
 		if (this.opts.languages) {
-			[].concat(this.opts.languages).forEach( (l) => {
+			[].concat(this.opts.languages).forEach((l) => {
 				app.import(`node_modules/prismjs/components/prism-${l}.js`);
 			});
 		}
 
 		if (this.opts.theme) {
-			app.import(`node_modules/prismjs/themes/prism-${this.opts.theme}.css`);
+			app.import(
+				`node_modules/prismjs/themes/prism-${this.opts.theme}.css`
+			);
 		} else {
 			app.import(`node_modules/prismjs/themes/prism.css`);
 		}
 
 		app.import('vendor/prism.js', {
-			exports: { prism: ['default'] }
+			exports: { prism: ['default'] },
 		});
-
 	},
-
 };

--- a/packages/prism.js/package.json
+++ b/packages/prism.js/package.json
@@ -18,7 +18,7 @@
     "@ascua/decorators": "file:../decorators",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-htmlbars": "^5.7.1",
-    "prismjs": "^1.27.0"
+    "prismjs": "^1.29.0"
   },
   "ember-addon": {
     "demoURL": "https://abcum.github.io/ascua",


### PR DESCRIPTION
Prism provides a plugin adding a "copy to the clipboard" button on top of the code block.

https://prismjs.com/plugins/copy-to-clipboard/

This PR adds the option "copyToClipboard" to the prism package.